### PR TITLE
Ruby version up to 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## 必ずこの日時でリリースする or この日時でリリースできるとよさそう

いつでも

## このPRの背景

Ruby 3.2 へとバージョンを上げても CI が動くようにするため

## このPRで対応したこと

.github/workflows/ci.yml に 3.2 を追記した。